### PR TITLE
Added dedupe function and remove @ from the ghLink

### DIFF
--- a/web/src/components/Attendees/index.js
+++ b/web/src/components/Attendees/index.js
@@ -3,12 +3,37 @@ import React from 'react'
 import { Attendees } from './elements'
 import shuffle from '../../helpers/shuffle'
 
+const dedupeAttendees = (attendeesArray) => {
+  const list = [];
+  const deduped = ourList.reduce((acc, current) => {
+    const cleanGhLink = current.ghLink.startsWith('@') ? current.ghLink.slice(1) : current.ghLink
+
+
+    if (list.includes(cleanGhLink)) {
+      return acc;
+    }
+
+    list.push(cleanGhLink)
+    acc.push(current)
+
+    return acc
+  }, [])
+
+  return deduped
+}
+
 export default ({ attendees }) => {
+
+  const dedupedAttendees = dedupeAttendees(attendees)
+
   return (
     <Attendees>
-      {shuffle(attendees).map(a => {
-       // Pretty ugly but this way we do not get duplicate https://github.com urls
-       const ghLink = `https://github.com/${a.ghLink.trim().replace('https://github.com/', '')}`;
+      {shuffle(dedupedAttendees).map(a => {
+        // Pretty ugly but this way we do not get duplicate https://github.com urls
+
+        const cleanGhLink = a.ghLink.startsWith('@') ? a.ghLink.slice(1) : a.ghLink
+
+        const ghLink = `https://github.com/${cleanGhLink.trim().replace('https://github.com/', '')}`;
         return (<li key={a.id}>
           <a
             href={ghLink}

--- a/web/src/components/Attendees/index.js
+++ b/web/src/components/Attendees/index.js
@@ -5,7 +5,7 @@ import shuffle from '../../helpers/shuffle'
 
 const dedupeAttendees = (attendeesArray) => {
   const list = [];
-  const deduped = ourList.reduce((acc, current) => {
+  const deduped = attendeesArray.reduce((acc, current) => {
     const cleanGhLink = current.ghLink.startsWith('@') ? current.ghLink.slice(1) : current.ghLink
 
 


### PR DESCRIPTION
Some muppets (like me) use @GitHubName (given lack of explicit instructions). And because they are impatient and can't see the changes immediately, they resubmit with GitHubName.

This PR aims to deduplicate the list of attendees, and swap @GitHubName to GitHubName. 

This allows the list to reflect the true number of attendees, and prevent broken images / links (as it's currently the case). 

NOTE: the number of pictures is correct, the number on top is not (because the deduping is done in the child component) :-/ 