### PR TITLE
chore: add organizers link to header

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -49,9 +49,10 @@ const Header = ({ siteTitle }) => (
             title="QueerJS Shop"
             rel="noopener noreferrer"
           >
-            Donate to our open collective
+            Donate
           </NavHref>
         </li>
+        <li><NavLink to="/organizers">Organizers</NavLink> </li>
       </ul>
     </NavRow>
   </Nav>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -59,19 +59,6 @@ const IndexPage = ({ data: { allEvent } }) => {
           </Cities>
         </Panel>
       ) : null}
-
-      {/* <Thanks
-        organizers={[]}
-        thanks={[
-          {
-            link: 'https://www.flaticon.com',
-            name: 'Thank you to flaticon',
-            reason: 'icons'
-          }
-        ]}
-        site={site}
-        mainOrganizer={mainOrganizer.find(o => o.main)}
-      /> */}
     </Layout>
   )
 }


### PR DESCRIPTION
Does three things:

- Moves link to organizers into the top-level header
- Removes extra unused code from index
- Simplifies `Donate to our OC` to `Donate` for consistency w other links

<img width="562" alt="Screen Shot 2019-10-13 at 10 38 08 AM" src="https://user-images.githubusercontent.com/2036040/66719513-d88cbe80-eda5-11e9-9824-185fd748b214.png">
