### PR TITLE
feat: add an FAQ page

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -53,6 +53,7 @@ const Header = ({ siteTitle }) => (
           </NavHref>
         </li>
         <li><NavLink to="/organizers">Organizers</NavLink> </li>
+        <li><NavLink to="/faq">FAQ</NavLink> </li>
       </ul>
     </NavRow>
   </Nav>

--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -25,9 +25,9 @@ const FAQPage = () => {
         </Panel>
         <Panel heading="How can I get involved?">
           There are a lot of ways you could get involved with QueerJS! We're always looking for new locations to
-          host meetups, as well as folks on the ground to help coordinate and act as MCs for those meetups.
+          host meetups, as well as folks on the ground to act as local organizers and MCs.
           <br/><br/>
-          Coordination might involve working with your employers to provide a space, organizing catering for meetup
+          Involvement might mean working with your employers to provide a space, organizing catering for meetup
           attendees, ensuring that there is a livestream or opportunity to record the speakers, and generally working
           to ensure that the meetup runs smoothly.
           <br/><br/>

--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -1,0 +1,113 @@
+import React from 'react'
+import SEO from '../components/seo'
+import Layout from '../containers/layout'
+import Panel from '../components/Panel'
+
+const FAQPage = () => {
+  return (
+    <Layout>
+      <SEO
+        title="QueerJS - Organizers"
+        description="A meetup for everyone where Queer Speakers take the stage"
+      />
+      <main>
+        <h1 hidden>Welcome to QueerJS</h1>
+        <Panel heading="FAQ"></Panel>
+        <Panel heading="How do I speak at QueerJS?">
+          We'd love for you to speak at a meetup! Please see {' '}  
+          <a
+            href="/speak"
+            rel="noopener noreferrer"
+            title="Speak"
+          >
+            Speaking at QueerJS
+          </a> for more information about how you can propose a talk to a future iteration of QueerJS.
+        </Panel>
+        <Panel heading="How can I get involved?">
+          There are a lot of ways you could get involved with QueerJS! We're always looking for new locations to
+          host meetups, as well as folks on the ground to help coordinate and act as MCs for those meetups.
+          <br/><br/>
+          Coordination might involve working with your employers to provide a space, organizing catering for meetup
+          attendees, ensuring that there is a livestream or opportunity to record the speakers, and generally working
+          to ensure that the meetup runs smoothly.
+          <br/><br/>
+          If you think you'd like to do this, we'd love to work with you to make
+          it happen - please contact us via {' '}
+          <a
+            href="https://twitter.com/QueerJS"
+            rel="noopener noreferrer"
+            title="Twitter"
+            target="_blank"
+          >
+            Twitter
+          </a>
+          , or email us at {' '}
+          <a
+            href="hello@queerjs.com"
+            rel="noopener noreferrer"
+            title="Email"
+          >
+            hello@queerjs.org
+          </a>!
+        </Panel>
+        <Panel heading="Where does QueerJS happen?">
+          We have a bunch of meetups being planned all over the globe{' '}
+          <span role="img" aria-label="earth">
+            🌍
+          </span>{' '}
+          You can check the{' '}
+          <a
+            href="/"
+            title="Cities"
+            rel="noopener noreferrer"
+          >
+            Cities
+          </a>{' '}
+          page for a list of the upcoming (and past) meetups.
+        </Panel>
+        <Panel heading="Can I print and redistribute the meetup stickers?">
+          Yes! They're all open source and you can find them in our {' '}
+          <a
+            href="https://github.com/queerjs/brand-assets"
+            title="Brand Assets"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Brand Assets
+          </a>{' '}
+          repository on GitHub.
+        </Panel>
+        <Panel heading="Any other questions?">
+          Please {' '}
+          <a
+            href="https://github.com/queerjs/info/issues/new"
+            rel="noopener noreferrer"
+            title="QueerJS Info"
+            target="_blank"
+          >
+          open an issue
+          </a>
+          , send us a message on {' '}
+          <a
+            href="https://twitter.com/QueerJS"
+            rel="noopener noreferrer"
+            title="Twitter"
+            target="_blank"
+          >
+            Twitter
+          </a>
+          , or email us at {' '}
+          <a
+            href="hello@queerjs.com"
+            rel="noopener noreferrer"
+            title="Email"
+          >
+            hello@queerjs.org
+          </a>!
+        </Panel>
+      </main>
+    </Layout>
+  )
+}
+
+export default FAQPage

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,8 +28,8 @@ const IndexPage = ({ data: { allEvent } }) => {
       />
       <Panel>
         <LargeParagraph>
-          QueerJS is a meetup series where all are encouraged to attend and support the speakers
-          and the idea, but where all the speakers should identify as queer.
+          QueerJS is a meetup series where everyone is encouraged to attend and support the speakers
+          and the idea, but where all speakers are queer.
           <br/><br/>
           This meetup exists to give a voice to everyone and to make a safe space where everyone is
           welcome.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,10 +28,10 @@ const IndexPage = ({ data: { allEvent } }) => {
       />
       <Panel>
         <LargeParagraph>
-          QueerJS is a series of meetups where anyone is welcome to attend and support the speakers
-          and the idea but all the speakers will be Queer.
-          <br />
-          This meetup exists to give a voice to everyone, to make a safe space where everyone is
+          QueerJS is a meetup series where all are encouraged to attend and support the speakers
+          and the idea, but where all the speakers should identify as queer.
+          <br/><br/>
+          This meetup exists to give a voice to everyone and to make a safe space where everyone is
           welcome.
         </LargeParagraph>
         <LargeParagraph>

--- a/src/pages/organizers.js
+++ b/src/pages/organizers.js
@@ -12,14 +12,17 @@ const capitalize = s => {
 }
 
 const OrganizersPage = () => {
+  const { site } = {
+    site: {
+      title: 'QueerJS',
+      description: 'A meetup for everyone where Queer Speakers take the stage'
+    }
+  }
   return (
     <Layout>
-      <SEO
-        title="QueerJS - Organizers"
-        description="A meetup for everyone where Queer Speakers take the stage"
-      />
+      <SEO title={site.title} description={site.description} />
       <main>
-        <h1 hidden>Welcome to QueerJS</h1>
+        <h1 hidden>Welcome to {site.title}</h1>
         <Panel heading="Organizers">
           <p>
             Nothing can be organized by only one person and there is a team helping QueerJS be a

--- a/src/pages/speak.js
+++ b/src/pages/speak.js
@@ -68,22 +68,6 @@ export default () => {
           lightning talks. So do whatever you feel most comfortable with! If you need more time to
           present, please let us know so we can adjust the schedule or coordinate with the venue.
         </Panel>
-        <Panel heading="Where does QueerJS happen?">
-          We have a bunch of meetups being planned all over the globe{' '}
-          <span role="img" aria-label="earth">
-            🌍
-          </span>{' '}
-          You can check the{' '}
-          <a
-            href="https://queerjs.com/"
-            title="QueerJS website"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            QueerJS website
-          </a>{' '}
-          for a list of the upcoming (and past) meetups.
-        </Panel>
         <Panel heading="What if the lineup for the location I want to speak at is full?">
           It's very, very likely that if we host a QueerJS in a city, we'll do it again in the same
           city one day. So we'd still encourage you to submit your talk. That way, you'll be at the


### PR DESCRIPTION
Add an FAQ page to the top header bar - includes more visible contact links, a section about getting involved, and more links to speaking information.

Also some cleanup of a few other things for consistency.

cc @walaura 