### PR TITLE
fix: donate tooltip text in navbar

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -46,7 +46,7 @@ const Header = ({ siteTitle }) => (
           <NavHref
             href="https://opencollective.com/queerjs"
             target="_blank"
-            title="QueerJS Shop"
+            title="Donate to QueerJS"
             rel="noopener noreferrer"
           >
             Donate


### PR DESCRIPTION
Closes https://github.com/queerjs/website/issues/53.

`QueerJS Shop` -> `Donate to QueerJS`

<img width="571" alt="Screen Shot 2019-12-16 at 11 31 02 AM" src="https://user-images.githubusercontent.com/2036040/70936653-97a86480-1ff7-11ea-818b-695948685891.png">

cc @carolstran 