### PR TITLE
feat: add local organizer responsibilities

### DIFF
--- a/src/components/Attendees/elements.js
+++ b/src/components/Attendees/elements.js
@@ -27,4 +27,8 @@ export const Attendees = styled.ul`
       background-color: rgb(230, 230, 230);
     }
   }
+  li {
+    list-style: none;
+  }
 `
+

--- a/src/components/Speakers/elements.js
+++ b/src/components/Speakers/elements.js
@@ -86,6 +86,7 @@ export const UnstyledLink = styled(Link)`
 
 export const ListItem = styled.li`
   position: relative;
+  list-style: none;
   ${props =>
     !props.talk &&
     `

--- a/src/components/header/elements.js
+++ b/src/components/header/elements.js
@@ -21,6 +21,8 @@ export const NavRow = styled.section`
   ul,
   li {
     display: inline;
+    margin: 0;
+    padding: 0;
   }
   ul {
     @media screen and (max-width: 38em) {

--- a/src/components/layout/elements.js
+++ b/src/components/layout/elements.js
@@ -41,15 +41,6 @@ body > div > div {
   height: 100%;
 }
 
-ul li {
-  list-style: none;
-}
-
-ul {
-  margin: 0;
-  padding: 0;
-}
-
 figure {
   margin: 0;
 }

--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import SEO from '../components/seo'
 import Layout from '../containers/layout'
+import { Link } from 'gatsby'
 import Panel from '../components/Panel'
 
 const FAQPage = () => {
@@ -24,31 +25,9 @@ const FAQPage = () => {
           </a> for more information about how you can propose a talk to a future iteration of QueerJS.
         </Panel>
         <Panel heading="How can I get involved?">
-          There are a lot of ways you could get involved with QueerJS! We're always looking for new locations to
-          host meetups, as well as folks on the ground to act as local organizers and MCs.
-          <br/><br/>
-          Involvement might mean working with your employers to provide a space, organizing catering for meetup
-          attendees, ensuring that there is a livestream or opportunity to record the speakers, and generally working
-          to ensure that the meetup runs smoothly.
-          <br/><br/>
-          If you think you'd like to do this, we'd love to work with you to make
-          it happen - please contact us via {' '}
-          <a
-            href="https://twitter.com/QueerJS"
-            rel="noopener noreferrer"
-            title="Twitter"
-            target="_blank"
-          >
-            Twitter
-          </a>
-          , or email us at {' '}
-          <a
-            href="hello@queerjs.com"
-            rel="noopener noreferrer"
-            title="Email"
-          >
-            hello@queerjs.org
-          </a>!
+          There are a lot of ways you could get involved with QueerJS! See{' '}
+          <Link to="/getting-involved"> Getting Involved </Link>
+          for more information.
         </Panel>
         <Panel heading="Where does QueerJS happen?">
           We have a bunch of meetups being planned all over the globe{' '}

--- a/src/pages/getting-involved.js
+++ b/src/pages/getting-involved.js
@@ -52,8 +52,9 @@ const GettingInvolvedPage = () => {
           Local organizers are the point people for any given QueerJS event, and are key to its success.
           If you would like to be a local organizer, you should be prepared to:
           <ul>
-            <li> Ensure there is adequate seating for the RSVP'd number of attendees at the selected venue </li>
-            <li> Coordinate recording of event (and individual speakers) with onsite hosts </li>
+            <li> Take point on finding a venue and date to hold the event. </li>
+            <li> Ensure there is adequate seating for the RSVP'd number of attendees at the selected venue. </li>
+            <li> Coordinate recording of event (and individual speakers) with onsite hosts, if possible. </li>
             <li> Coordinate food with onsite hosts, which may either be:
               <ul>
                 <li> Provided by onsite hosts </li>

--- a/src/pages/getting-involved.js
+++ b/src/pages/getting-involved.js
@@ -1,0 +1,88 @@
+import React from 'react'
+import SEO from '../components/seo'
+import Layout from '../containers/layout'
+import { Link } from 'gatsby'
+import Panel, { LargeParagraph } from '../components/Panel'
+
+const GettingInvolvedPage = () => {
+  return (
+    <Layout>
+      <SEO
+        title="QueerJS - Getting Involved"
+        description="A meetup for everyone where Queer Speakers take the stage"
+      />
+      <main>
+        <Panel>
+          <LargeParagraph>
+            There are a lot of ways you could get involved with QueerJS!
+            <br />
+            <br />
+            If you think you'd like to do this, we'd love to work with you to make
+            it happen - please contact us via {' '}
+            <a
+              href="https://twitter.com/QueerJS"
+              rel="noopener noreferrer"
+              title="Twitter"
+              target="_blank"
+            >
+              Twitter
+            </a>
+            , or email us at {' '}
+            <a
+              href="hello@queerjs.com"
+              rel="noopener noreferrer"
+              title="Email"
+            >
+              hello@queerjs.org
+            </a>!
+          </LargeParagraph>
+        </Panel>
+        <Panel heading="Getting Involved"></Panel>
+        <p>
+          We're always looking for new locations to host meetups, as well as folks on the ground
+          to act as local organizers and MCs.
+          <br />
+          <br />
+          Involvement might include working with your employers to provide a space, organizing
+          catering for meetup attendees, ensuring that there is a livestream or opportunity to
+          record the speakers, and generally working to ensure that the meetup runs smoothly.
+        </p>
+        <Panel heading="What Do Local Organizers Do?"></Panel>
+        <p>
+          Local organizers are the point people for any given QueerJS event, and are key to its success.
+          If you would like to be a local organizer, you should be prepared to:
+          <ul>
+            <li> Ensure there is adequate seating for the RSVP'd number of attendees at the selected venue </li>
+            <li> Coordinate recording of event (and individual speakers) with onsite hosts </li>
+            <li> Coordinate food with onsite hosts, which may either be:
+              <ul>
+                <li> Provided by onsite hosts </li>
+                <li> Ordered by local organizer and reimbursed through QueerJS' {' '}
+                  <a
+                    href="https://opencollective.com/queerjs"
+                    rel="noopener noreferrer"
+                    title="OpenCollective"
+                  >
+                    OpenCollective
+                  </a>!
+                </li>
+              </ul>
+            </li>
+            <li> Ensure the {' '}
+              <Link to="/code-of-conduct"> Code of Conduct</Link>{' '}
+              is read to attendees at the beginning of the event.
+            </li>
+              <ul>
+                <li> Mention{' '}
+                  <Link to="/report"> reporting mechanisms</Link>{' '}
+                  for CoC violations should they occur. </li>
+              </ul>
+            <li> Ensure the venue is cleaned following the close of the event. </li>
+          </ul>
+        </p>
+      </main>
+    </Layout>
+  )
+}
+
+export default GettingInvolvedPage

--- a/src/pages/organizers.js
+++ b/src/pages/organizers.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import SEO from '../components/seo'
 import Layout from '../containers/layout'
+import { Link } from 'gatsby'
 import Panel from '../components/Panel'
 import Speakers from '../components/Speakers'
 
@@ -25,10 +26,13 @@ const OrganizersPage = () => {
         <h1 hidden>Welcome to {site.title}</h1>
         <Panel heading="Organizers">
           <p>
-            Nothing can be organized by only one person and there is a team helping QueerJS be a
+            Nothing can be organized by only one person - there is a team helping QueerJS be a
             safe space all over the world.
           </p>
-          <p>The cities indicate what events they helped organize</p>
+          <p>The cities indicate what events they helped organize. Want to help organize a
+            meetup in your own city? See some of the ways you can{' '}
+            <Link to="/getting-involved"> get involved</Link>.
+          </p>
           <p
             css={`
               margin-bottom: 40px;

--- a/src/pages/report.js
+++ b/src/pages/report.js
@@ -37,15 +37,15 @@ const Report = () => {
               some ways you can report it to us:
             </p>
             <ul>
-              <li>- Send a DM to {contactInfo.twitterHandle}</li>
+              <li> Send a DM to {contactInfo.twitterHandle}</li>
               <li>
-                - Let a{' '}
+                Let a{' '}
                 <Link to="/organizers" title="Code of Conduct">
                   Core Team
                 </Link>{' '}
                 organizer know, either in person or via Twitter.
               </li>
-              <li>- Send an email to <a href={`mailto:${contactInfo.email}`}>{contactInfo.email}</a></li>
+              <li> Send an email to <a href={`mailto:${contactInfo.email}`}>{contactInfo.email}</a></li>
             </ul>
           </section>
         </Panel>


### PR DESCRIPTION
Add a page outlining what local organizers should expect to take responsibility for, and shuffle links around accordingly. I also changed the `ul`/`li` styles a little, to allow more bespoke bulleted lists where we want them.

Sample new page:

<img width="1378" alt="Screen Shot 2020-01-21 at 10 27 59 PM" src="https://user-images.githubusercontent.com/2036040/72870545-54e44700-3c9d-11ea-9e23-01db08a1b60e.png">

cc @carolstran @SaraVieira 