### PR TITLE
Adds features to reflect postponement of Tokyo March event

### DIFF
--- a/data/tokyo.yaml
+++ b/data/tokyo.yaml
@@ -2,7 +2,8 @@
 info:
   city: Tokyo
   link: tokyo
-  date: 03/24/2020
+  date: 6/1/2020
+  bySeason: Summer 2020
   hour: '19:00'
   icon: icons/tokyo/tokyo.svg
   iconHover: icons/tokyo/tokyo-hover.svg

--- a/data/tokyo.yaml
+++ b/data/tokyo.yaml
@@ -25,7 +25,6 @@ mainOrganizer:
     main: true
     twitterHandle: t0ky0rachel
     email: rachel@programmer.net
-organizers:
   - name: Kristina Yasuda
     twitterHandle: kristinayasuda
 sponsors:

--- a/data/tokyo.yaml
+++ b/data/tokyo.yaml
@@ -12,10 +12,13 @@ info:
 site:
   cfp: true
   city: Tokyo
-  location: Microsoft Shinagawa
+  location: TBD
   organizers: []
-  googleMapsLink: https://www.google.com/maps/place/%E6%97%A5%E6%9C%AC%E3%83%9E%E3%82%A4%E3%82%AF%E3%83%AD%E3%82%BD%E3%83%95%E3%83%88%E6%A0%AA%E5%BC%8F%E4%BC%9A%E7%A4%BE/@35.626638,139.7405616,15z/data=!4m5!3m4!1s0x0:0xe464accc1e5e8aa4!8m2!3d35.626638!4d139.7405616
-  calendarLink: https://www.google.com/calendar/render?action=TEMPLATE&text=QueerJS+Tokyo+Meetup&details=First+ever+QueerJS+event+in+Tokyo.&location=Microsoft+Shinagawa&dates=20200324T100000Z%2F20200323T123000Z
+  googleMapsLink: 
+  calendarLink: 
+announcement:
+  heading: Postponed
+  text: Due to the current situation regarding COVID-19, this event has been postponed. Please check back here for news regarding a new date and time. We hope to see you all this summer!
 mainOrganizer:
   - name: Rachel Ponce
     main: true

--- a/src/components/Announcement/index.js
+++ b/src/components/Announcement/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const DistinctiveDiv = styled.div`
+  background-color: ${props => props.theme.lightGrey};
+  color: ${props => props.theme.darkPurple};
+  margin-bottom: 2.5rem;
+  padding: 0.5rem;
+`
+
+const BoldTitle = styled.h2`
+  text-align: center;
+  text-transform: uppercase;
+`
+
+const Announcement = ({ message }) => {
+  return (
+    <DistinctiveDiv>
+      <BoldTitle>{message.heading}</BoldTitle>
+      <p>{message.text}</p>
+    </DistinctiveDiv>
+  )
+}
+
+export default Announcement;

--- a/src/components/City/index.js
+++ b/src/components/City/index.js
@@ -5,8 +5,9 @@ import { format } from 'date-fns'
 
 import { Wrapper, sizes, CityInfo, CityIcon, Cities, Name, MeetupDate, Host } from './elements'
 
-const City = ({ past, city, link, date, icon, iconHover, hostIcon, hostName }) => {
+const City = ({ past, city, link, date, bySeason, icon, iconHover, hostIcon, hostName }) => {
   const [hoverRef, isHovering] = useHover()
+
   return (
     <Wrapper
       itemscope
@@ -24,7 +25,11 @@ const City = ({ past, city, link, date, icon, iconHover, hostIcon, hostName }) =
       </CityIcon>
       <CityInfo>
         <MeetupDate itemprop={date} content="2013-09-14T21:30" past={past}>
-          {format(date, 'Do MMMM')}
+          {bySeason ?
+            <p>{bySeason}</p>
+          :
+            format(date, 'Do MMMM')
+          }
         </MeetupDate>
         <Name past={past} itemprop="name">
           {city}

--- a/src/components/City/index.js
+++ b/src/components/City/index.js
@@ -26,7 +26,7 @@ const City = ({ past, city, link, date, bySeason, icon, iconHover, hostIcon, hos
       <CityInfo>
         <MeetupDate itemprop={date} content="2013-09-14T21:30" past={past}>
           {bySeason ?
-            <p>{bySeason}</p>
+            <span>{bySeason}</span>
           :
             format(date, 'Do MMMM')
           }

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -29,9 +29,13 @@ export default ({ site, city, info, attendeesNumber }) => {
         </span>
 
         <span>
-          <a href={site.calendarLink} title="Add to Calendar">
-            {info.hour} {format(date, ['Do [of] MMMM '])}
-          </a>
+          {info.bySeason ?
+            <p>{info.bySeason}</p>
+          :
+            <a href={site.calendarLink} title="Add to Calendar">
+              {info.hour} {format(date, ['Do [of] MMMM '])}
+            </a>
+          }
         </span>
         <Calendar />
       </Info>

--- a/src/pages/_main.js
+++ b/src/pages/_main.js
@@ -9,9 +9,10 @@ import Attendees from '../components/Attendees'
 import Thanks from '../components/Thanks'
 import Panel from '../components/Panel'
 import Heading from '../components/Heading'
+import Announcement from '../components/Announcement'
 
 const Main = ({ city, attendees }) => {
-  const { site, thanks, speakers, sponsors, info, mainOrganizer } = city
+  const { site, thanks, speakers, sponsors, info, mainOrganizer, announcement } = city
 
   return (
     <Layout>
@@ -21,6 +22,9 @@ const Main = ({ city, attendees }) => {
       />
       <section>
         <Heading sub="queerjs @">{info.city}</Heading>
+        { announcement &&
+          <Announcement message={announcement} />
+        }
         <Info attendeesNumber={attendees.length} site={site} info={info} city={info.link} />
         <Panel heading="What?">
           {site.customDescription ? (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -76,6 +76,7 @@ export const query = graphql`
             city
             link
             date
+            bySeason
             hour
             hostName
             hour

--- a/src/templates/city.js
+++ b/src/templates/city.js
@@ -30,6 +30,7 @@ export const query = graphql`
         food
         hour
         date
+        bySeason
         maxCapacity
         rsvpsClosed
       }

--- a/src/templates/city.js
+++ b/src/templates/city.js
@@ -41,6 +41,10 @@ export const query = graphql`
         cfp
         customDescription
       }
+      announcement {
+        heading
+        text
+      }
       mainOrganizer {
         name
         main


### PR DESCRIPTION
This PR incorporates 2 new features to reflect the fact that Tokyo will have to be postponed:

1) It creates an announcement component so that event-specific announcements can be added to an event.yaml file
<img width="754" alt="Screen Shot 2020-03-14 at 9 54 13 PM" src="https://user-images.githubusercontent.com/42755840/76682312-6531f600-663e-11ea-9921-8757de2eb267.png">

2) A bySeason option has been added to the event.yaml in the event's info which will force the event to display descriptive text instead of a specific date for an event. I did this because we don't have a new date for Tokyo just yet, but I would like for people who have previously RSVP'd to still see the information about the event as pending.

<img width="808" alt="Screen Shot 2020-03-14 at 9 53 32 PM" src="https://user-images.githubusercontent.com/42755840/76682304-4df30880-663e-11ea-85eb-3a7f2cc05c75.png">
