### PR TITLE
Cleans up some console & linter warnings

### DIFF
--- a/src/components/City/index.js
+++ b/src/components/City/index.js
@@ -9,10 +9,10 @@ const City = ({ past, city, link, date, icon, iconHover, hostIcon, hostName }) =
   const [hoverRef, isHovering] = useHover()
   return (
     <Wrapper
-      itemscope
-      itemtype="http://schema.org/Event"
+      itemScope
+      itemType="http://schema.org/Event"
       title={`QueerJS ${city}`}
-      to={link}
+      to={`/${link}`}
       innerRef={hoverRef}
     >
       <CityIcon>

--- a/src/components/rainbow/Rainbow.js
+++ b/src/components/rainbow/Rainbow.js
@@ -1,10 +1,9 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import { Stripe, SubWrapper, Wrapper } from './elements'
 
-const max = 10
-
 export default ({ stripes, children, ...other }) => {
-  const streeps = useMemo(() => new Array(max).fill(undefined), [max])
+  const max = 10
+  const streeps = new Array(max).fill(undefined);
 
   return (
     <Wrapper {...other}>

--- a/src/helpers/useHover.js
+++ b/src/helpers/useHover.js
@@ -2,14 +2,13 @@ import { useRef, useEffect, useCallback, useState } from 'react'
 
 export const canHover =
   typeof window !== 'undefined' ? !window.matchMedia('(hover: none)').matches : false
-const emptyArr = []
 
 export default (enterDelay, leaveDelay) => {
   const [isHovering, setHovering] = useState(false)
   const timeout = useRef(null)
   const element = useRef(null)
   // here for compatibility reasons with certain libs
-  const setElementRef = useCallback(el => (element.current = el), emptyArr)
+  const setElementRef = useCallback(el => (element.current = el), [])
   const toggle = useCallback((value, delay) => {
     if (canHover === false) {
       return
@@ -25,7 +24,7 @@ export default (enterDelay, leaveDelay) => {
     } else {
       setHovering(value)
     }
-  }, emptyArr)
+  }, [])
   const onEnter = useCallback(() => toggle(true, enterDelay), [enterDelay, toggle])
   const onLeave = useCallback(() => toggle(false, leaveDelay), [leaveDelay, toggle])
 
@@ -41,8 +40,8 @@ export default (enterDelay, leaveDelay) => {
         element.current.removeEventListener('mouseleave', onLeave)
       }
     }
-  }, [element.current, onEnter, onLeave])
+  }, [onEnter, onLeave])
   // cleans up timeout on unmount
-  useEffect(() => () => timeout.current !== null && clearTimeout(timeout.current), emptyArr)
+  useEffect(() => () => timeout.current !== null && clearTimeout(timeout.current), [])
   return [setElementRef, isHovering]
 }


### PR DESCRIPTION
On the homepage, we were getting a lot of errors from Gatsby about the event links:
<img width="672" alt="Screen Shot 2020-03-14 at 10 03 27 PM" src="https://user-images.githubusercontent.com/42755840/76682455-b7bfe200-663f-11ea-8959-30bc5833173f.png">

We were also getting errors about the html properties for itemtype and itemscope:
<img width="678" alt="Screen Shot 2020-03-14 at 10 04 46 PM" src="https://user-images.githubusercontent.com/42755840/76682488-dde58200-663f-11ea-89e0-cf476f50ee97.png">

And then there were some linter complaints about the hooks in the Rainbow.js and useHover helper modules:
<img width="641" alt="Screen Shot 2020-03-14 at 10 05 23 PM" src="https://user-images.githubusercontent.com/42755840/76682509-07061280-6640-11ea-9978-9389dc4fb159.png">

For Rainbow.js, the savings of using memo in that case seemed so minimal that I felt it wasn't worth the added complexity. So I removed the memoization entirely.

<img width="641" alt="Screen Shot 2020-03-14 at 10 05 33 PM" src="https://user-images.githubusercontent.com/42755840/76682574-99a6b180-6640-11ea-81ec-5545ed855a88.png">

In useHover, I think the linter was right to complain -- as much as it seems gross to keep creating new empty arrays, I do believe each hook _should_ have it's own empty array passed in as a unique dependency and not the same array. I do realize it was working as is, so I could be wrong about that. But I feel again like reusing one empty array might be a micro-optimization that could lead to wonky bugs down the line. But mostly I just wanted my console log to be clean :-)
