### PR TITLE
Fixed mailto links for hello@queerjs.com

### DIFF
--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -77,7 +77,7 @@ const FAQPage = () => {
           </a>
           , or email us at {' '}
           <a
-            href="hello@queerjs.com"
+            href="mailto:hello@queerjs.com"
             rel="noopener noreferrer"
             title="Email"
           >

--- a/src/pages/getting-involved.js
+++ b/src/pages/getting-involved.js
@@ -29,7 +29,7 @@ const GettingInvolvedPage = () => {
             </a>
             , or email us at {' '}
             <a
-              href="hello@queerjs.com"
+              href="mailto:hello@queerjs.com"
               rel="noopener noreferrer"
               title="Email"
             >


### PR DESCRIPTION
The links to email hello@queerjs.com on the FAQ and Getting Involved pages tried to navigate to, for example, `https://queerjs.com/faq/hello@queerjs.com`, so I replaced them with `mailto:` hrefs.