### PR TITLE
bug: remove scam Twitter link

### DIFF
--- a/data/amsterdam.yaml
+++ b/data/amsterdam.yaml
@@ -44,7 +44,6 @@ speakers:
     twitterLink: jayne_mast
     githubLink: jayne-mast
   - name: Ash Kyd
-    twitterLink: ashkyd
     githubLink: ashkyd
   - name: Ives van Hoorne
     twitterLink: CompuIves

--- a/data/online-2020-16.yaml
+++ b/data/online-2020-16.yaml
@@ -31,7 +31,6 @@ mainOrganizer:
     githubLink: pixelyunicorn
   - name: Ash Kyd
     email: ash@kyd.com.au
-    twitterHandle: ashkyd
 organizers:
   - name: Paola Ducolin
     twitterHandle: PolaDuco


### PR DESCRIPTION
Twitter is dead, this is just someone impersonating me. Best remove it :]

Edit: looks like the node version is too old in the build. Might be an easy version bump, LMK if you'd like me to try updating things.